### PR TITLE
Ensures screen size initialization on app start

### DIFF
--- a/lib/main_development.dart
+++ b/lib/main_development.dart
@@ -1,8 +1,10 @@
 import 'package:doc_app/core/di/service_locator.dart';
 import 'package:doc_app/doc_app.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 
-void main() {
+void main() async{
   setupServiceLocator();
+  await ScreenUtil.ensureScreenSize();
   runApp(const DocApp());
 }

--- a/lib/main_production.dart
+++ b/lib/main_production.dart
@@ -1,8 +1,10 @@
 import 'package:doc_app/core/di/service_locator.dart';
 import 'package:doc_app/doc_app.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 
-void main() {
+void main() async{
   setupServiceLocator();
+  await ScreenUtil.ensureScreenSize();
   runApp(const DocApp());
 }


### PR DESCRIPTION
Ensures that the screen size is properly initialized before the app runs.

This resolves an issue where text may not appear correctly in release builds.