### PR TITLE
Updates branch name in Firebase workflow

### DIFF
--- a/.github/workflows/android_fastlane_firebase_app_distribution_workflow.yml
+++ b/.github/workflows/android_fastlane_firebase_app_distribution_workflow.yml
@@ -3,7 +3,7 @@ name: Android Fastlane with Firebase App Distribution Workflow
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   distribute_to_firebase:


### PR DESCRIPTION
Updates the workflow to trigger on the `main` branch instead of `master`.

This ensures the Firebase App Distribution workflow is correctly triggered when pushing to the primary branch.